### PR TITLE
Add traversaro in mantainer team and fix license to be SPDX compliant

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @repagh
+* @repagh @traversaro

--- a/README.md
+++ b/README.md
@@ -177,4 +177,5 @@ Feedstock Maintainers
 =====================
 
 * [@repagh](https://github.com/repagh/)
+* [@traversaro](https://github.com/traversaro/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -105,3 +105,4 @@ about:
 extra:
   recipe-maintainers:
     - repagh
+    - traversaro

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -96,7 +96,7 @@ outputs:
 
 about:
   home: https://www.ode.org/
-  license: LGPL-2.0 or BSD-4-Clause
+  license: LGPL-2.1-or-later OR BSD-4-Clause
   summary: Open Dynamics Engine, dynamics simulation
   license_file:
     - LICENSE.TXT


### PR DESCRIPTION
See https://github.com/conda-forge/libode-feedstock/pull/5#issuecomment-804683907 for the maintainers discussion, and given that I was at it I also fixed the "License is not an SPDX identifier (or a custom LicenseRef) nor an SPDX license expression." conda-forge-linter warning.

I did not bumper the build number as this change do not need to be reflected in a new build.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
