### PR TITLE
Fix installation of include in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About libode
 
 Home: https://www.ode.org/
 
-Package license: LGPL-2.0 or BSD-4-Clause
+Package license: LGPL-2.1-or-later OR BSD-4-Clause
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/libode-feedstock/blob/master/LICENSE.txt)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - modify-dotpc-win.patch         # [win]
 
 build:
-  number: 4
+  number: 5
   skip: true                         # [win and py==27]
   # add libode to the whitelist; it can apparently not be found yet when
   # pyode is built
@@ -58,23 +58,27 @@ outputs:
       - lib/pkgconfig/ode.pc                                         # [unix]
       - lib/cmake/ode-{{ soversion }}                                # [unix]
       - bin/ode-config                                               # [unix]
+      - include/ode                                                  # [unix]
       - Library/lib/ode_double.lib                                   # [win]
       - Library/bin/ode_double.dll                                   # [win]
       - Library/lib/pkgconfig/ode.pc                                 # [win]
       - Library/lib/cmake/ode-{{ soversion }}                        # [win]
-      - include/ode
+      - Library/include/ode                                          # [win]
+ 
+     
     test:
       commands:
         - test -f $PREFIX/lib/libode${SHLIB_EXT}                     # [unix]
         - test -f $PREFIX/lib/libode${SHLIB_EXT}.{{ soversion }}     # [linux]
         - test -f $PREFIX/lib/libode.{{ soversion }}${SHLIB_EXT}     # [osx]
-        - test -d $PREFIX/include/ode                                # [unix]
+        - test -d $PREFIX/include/ode/ode.h                          # [unix]
         - test -f $PREFIX/lib/pkgconfig/ode.pc                       # [unix]
         - test -f $PREFIX/lib/cmake/ode-{{ soversion }}/ode-config.cmake  # [unix]
         - if not exist %PREFIX%\Library\lib\ode_double.lib exit 1    # [win]
         - if not exist %PREFIX%\Library\bin\ode_double.dll exit 1    # [win]
         - if not exist %PREFIX%\Library\lib\pkgconfig\ode.pc exit 1  # [win]
         - if not exist %PREFIX%\\Library\\lib\\cmake\\ode-{{ soversion }}\\ode-config.cmake  # [win]
+        - if not exist %PREFIX%\\Library\\include\\ode\\ode.h        # [win]
 
   - name: pyode
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,14 +71,14 @@ outputs:
         - test -f $PREFIX/lib/libode${SHLIB_EXT}                     # [unix]
         - test -f $PREFIX/lib/libode${SHLIB_EXT}.{{ soversion }}     # [linux]
         - test -f $PREFIX/lib/libode.{{ soversion }}${SHLIB_EXT}     # [osx]
-        - test -d $PREFIX/include/ode/ode.h                          # [unix]
+        - test -f $PREFIX/include/ode/ode.h                          # [unix]
         - test -f $PREFIX/lib/pkgconfig/ode.pc                       # [unix]
         - test -f $PREFIX/lib/cmake/ode-{{ soversion }}/ode-config.cmake  # [unix]
         - if not exist %PREFIX%\Library\lib\ode_double.lib exit 1    # [win]
         - if not exist %PREFIX%\Library\bin\ode_double.dll exit 1    # [win]
         - if not exist %PREFIX%\Library\lib\pkgconfig\ode.pc exit 1  # [win]
-        - if not exist %PREFIX%\\Library\\lib\\cmake\\ode-{{ soversion }}\\ode-config.cmake  # [win]
-        - if not exist %PREFIX%\\Library\\include\\ode\\ode.h        # [win]
+        - if not exist %PREFIX%\\Library\\lib\\cmake\\ode-{{ soversion }}\\ode-config.cmake exit 1 # [win]
+        - if not exist %PREFIX%\\Library\\include\\ode\\ode.h exit 1 # [win]
 
   - name: pyode
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,9 +76,9 @@ outputs:
         - test -f $PREFIX/lib/cmake/ode-{{ soversion }}/ode-config.cmake  # [unix]
         - if not exist %PREFIX%\Library\lib\ode_double.lib exit 1    # [win]
         - if not exist %PREFIX%\Library\bin\ode_double.dll exit 1    # [win]
-        - if not exist %PREFIX%\Library\lib\pkgconfig\ode.pc exit 1  # [win]
-        - if not exist %PREFIX%\\Library\\lib\\cmake\\ode-{{ soversion }}\\ode-config.cmake exit 1 # [win]
-        - if not exist %PREFIX%\\Library\\include\\ode\\ode.h exit 1 # [win]
+        - if not exist %PREFIX%\Library\lib\pkgconfig\ode.pc exit 1   # [win]
+        - if not exist %PREFIX%\\Library\\lib\\cmake\\ode-{{ soversion }}\\ode-config.cmake exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\include\\ode\\ode.h exit 1  # [win]
 
   - name: pyode
     requirements:


### PR DESCRIPTION
Yes another Windows fix, hopefully the last one. The Windows libode package did not included headers, so it could not be used to compile a downstream library. An existence test has been added to prevent regressions.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
