### PR TITLE
Set ODE_WITH_LIBCCD_BOX_CYL to OFF for consistency with autotools builds used in Linux distributions

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,9 +7,15 @@ env
 REM add future installation path to pkgconfig
 set PKG_CONFIG_PATH=%LIBRARY_PREFIX%\lib\pkgconfig;
 
+REM We pass -DODE_WITH_LIBCCD_BOX_CYL:BOOL=OFF for consistency with autotools builds that are
+REM used by the ode packages of major linux distributions
+REM https://github.com/conda-forge/dartsim-feedstock/issues/62
+REM https://bitbucket.org/odedevs/ode/src/bcfb66cd5e18e32e27cfaae3651ead930bbcda13/configure.ac#lines-428
+REM https://bitbucket.org/odedevs/ode/issues/87/box-cylinder-ccd-check-disabled-by-default
 cmake -G"NMake Makefiles" ^
       -DODE_WITH_LIBCCD:BOOL=ON ^
       -DODE_WITH_LIBCCD_SYSTEM:BOOL=ON ^
+      -DODE_WITH_LIBCCD_BOX_CYL:BOOL=OFF ^
       -DCMAKE_BUILD_TYPE=Release ^
       -DODE_WITH_DEMOS:BOOL=OFF ^
       -DODE_WITH_TESTS:BOOL=OFF ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,9 +4,15 @@ cp $BUILD_PREFIX/share/gnuconfig/config.* .
 mkdir _build
 cd _build
 
+# We pass -DODE_WITH_LIBCCD_BOX_CYL:BOOL=OFF for consistency with autotools builds that are
+# used by the ode packages of major linux distributions
+# https://github.com/conda-forge/dartsim-feedstock/issues/62
+# https://bitbucket.org/odedevs/ode/src/bcfb66cd5e18e32e27cfaae3651ead930bbcda13/configure.ac#lines-428
+# https://bitbucket.org/odedevs/ode/issues/87/box-cylinder-ccd-check-disabled-by-default
 cmake ${CMAKE_ARGS} -DCMAKE_BUILD_TYPE=Release \
       -DODE_WITH_LIBCCD:BOOL=ON \
       -DODE_WITH_LIBCCD_SYSTEM:BOOL=ON \
+      -DODE_WITH_LIBCCD_BOX_CYL:BOOL=OFF \
       -DODE_WITH_DEMOS:BOOL=OFF \
       -DODE_WITH_TESTS:BOOL=OFF .. \
       -DCMAKE_INSTALL_PREFIX:PATH="" \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - fix_system_ccd_cmake.patch
 
 build:
-  number: 13
+  number: 14
   run_exports:
     # No ABI docs or ABI Laboratory history, better be conservative
     - {{ pin_subpackage(name, max_pin='x.x.x') }}


### PR DESCRIPTION
Many major Linux distributions build ode with autotools, while in conda-forge we build it with CMake.

In ode there is a subtle difference between autotools and CMake builds, documented in https://github.com/conda-forge/dartsim-feedstock/issues/62 and https://bitbucket.org/odedevs/ode/issues/87/box-cylinder-ccd-check-disabled-by-default .

To make the conda-forge package of ode behave like most users probably expect, we set the CMake options to ensure that the build behaves like the autotools build, a bit like in https://github.com/conda-forge/libode-feedstock/pull/22 we enable the ccd dependency.

Fix https://github.com/conda-forge/dartsim-feedstock/issues/63 .


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
